### PR TITLE
Add source image support to instance plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,7 @@ coverage:
 test-full:
 	@echo "+ $@"
 	@go test -race $(PKGS)
+
+vendor-update:
+	@echo "+ $@"
+	@trash -u

--- a/plugin/instance/gcloud/api.go
+++ b/plugin/instance/gcloud/api.go
@@ -40,6 +40,7 @@ type InstanceSettings struct {
 	Tags        []string
 	Scopes      []string
 	DiskSizeMb  int64
+	SourceImage string
 	MetaData    []*compute.MetadataItems
 }
 
@@ -129,6 +130,10 @@ func (g *computeServiceWrapper) ListInstances() ([]*compute.Instance, error) {
 }
 
 func (g *computeServiceWrapper) CreateInstance(name string, settings *InstanceSettings) error {
+	diskImage := apiURL + g.project + "/global/images/docker"
+	if settings.SourceImage != "" {
+		diskImage = settings.SourceImage
+	}
 	instance := &compute.Instance{
 		Name:        name,
 		Description: settings.Description,
@@ -144,7 +149,7 @@ func (g *computeServiceWrapper) CreateInstance(name string, settings *InstanceSe
 				Mode:       "READ_WRITE",
 				InitializeParams: &compute.AttachedDiskInitializeParams{
 					DiskName:    name + "-disk",
-					SourceImage: apiURL + g.project + "/global/images/docker",
+					SourceImage: diskImage,
 					DiskSizeGb:  settings.DiskSizeMb,
 					DiskType:    apiURL + g.project + "/zones/" + g.zone + "/diskTypes/" + "pd-standard",
 				},

--- a/plugin/instance/plugin.go
+++ b/plugin/instance/plugin.go
@@ -28,6 +28,7 @@ type instanceProperties struct {
 	MachineType string
 	Network     string
 	DiskSizeMb  int64
+	SourceImage string
 	Tags        []string
 	Scopes      []string
 	TargetPool  string
@@ -117,6 +118,7 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 		Network:     properties.Network,
 		Tags:        properties.Tags,
 		DiskSizeMb:  properties.DiskSizeMb,
+		SourceImage: properties.SourceImage,
 		Scopes:      properties.Scopes,
 		MetaData:    gcloud.TagsToMetaData(tags),
 	}); err != nil {


### PR DESCRIPTION
Add support for `SourceImage` as part of the properties that can be passed to the instance plugin.

Partly fixes #1 

Example conf:
```
$ cat gcp-example.json
{
  "ID": "gcp-example",
  "Properties": {
    "Allocation": {
      "Size": 1
    },
    "Instance": {
      "Plugin": "instance-gcp",
      "Properties": {
        "NamePrefix": "test",
        "Description": "Test of GCP infrakit",
        "MachineType": "n1-standard-1",
        "DiskSizeMb": 60,
        "SourceImage": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20161205"
      }
    },
    "Flavor": {
      "Plugin": "flavor-vanilla",
      "Properties": {
        "Init": [
          "sh -c \"echo 'Hello, World!' > /hello\""
        ]
      }
    }
  }
}
```

`infrakit group commit gcp-example.json`

Output with deletion of the instance created in Gcloud after initial provisioning
```
INFO[1339] Committing group gcp-example (pretend=false)
INFO[1339] Adding 1 instances to group to reach desired 1
INFO[1360] Created instance test-5772011432076179851 with tags map[infrakit.config_sha:0udWPksKE0gSjY_VXT2-k3ZFxe8= infrakit.group:gcp-example]
INFO[1439] Adding 1 instances to group to reach desired 1
INFO[1456] Created instance test-6026652710436875390 with tags map[infrakit.config_sha:0udWPksKE0gSjY_VXT2-k3ZFxe8= infrakit.group:gcp-example]
```

cc @dgageot @chungers @wfarner 