### PR TITLE
Automation for docker image builds; proper version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,19 @@ clean:
 	rm -rf build
 	mkdir -p build
 
-binaries: clean
+define build_binary
+	go build -o build/$(1) \
+		-ldflags "-X github.com/docker/infrakit.gcp/plugin.Version=$(VERSION) -X github.com/docker/infrakit.gcp/plugin.Revision=$(REVISION)" $(2)
+endef
+binaries: clean build-binaries
+build-binaries:
 	@echo "+ $@"
-	@go build -o ./build/infrakit-instance-gcp \
-	  -ldflags "-X github.com/docker/infrakit/pkg/cli.Version=$(VERSION) -X github.com/docker/infrakit/pkg/cli.Revision=$(REVISION)" \
-	  plugin/instance/cmd/main.go
+ifneq (,$(findstring .m,$(VERSION)))
+	@echo "\nWARNING - repository contains uncommitted changes, tagging binaries as dirty\n"
+endif
+
+	$(call build_binary,infrakit-instance-aws,github.com/docker/infrakit.gcp/plugin/instance/cmd)
+
 
 install:
 	@echo "+ $@"
@@ -82,3 +90,40 @@ coverage:
 test-full:
 	@echo "+ $@"
 	@go test -race $(PKGS)
+
+get-tools:
+	@echo "+ $@"
+	@go get -u \
+		github.com/golang/lint/golint \
+		github.com/rancher/trash
+
+# Current working environment.  Set these explicitly if you want to cross-compile
+# in the build container (see the build-in-container target):
+GOOS?=$(shell go env GOOS)
+GOARCH?=$(shell go env GOARCH)
+DOCKER_BUILD_FLAGS?=--no-cache --pull
+build-in-container:
+	@echo "+ $@"
+	@docker build ${DOCKER_BUILD_FLAGS} -t infrakit-build -f ${CURDIR}/dockerfiles/Dockerfile.build .
+	@docker run --rm \
+		-e GOOS=${GOOS} -e GOARCCH=${GOARCH} -e DOCKER_CLIENT_VERSION=${DOCKER_CLIENT_VERSION} \
+		-v ${CURDIR}/build:/go/src/${REPO}/build \
+		infrakit-build
+
+# For packaging as Docker container images.  Set the environment variables DOCKER_PUSH, DOCKER_TAG_LATEST
+# if also push to remote repo.  You must have access to the remote repo.
+DOCKER_IMAGE?=infrakit/gcp
+DOCKER_TAG?=dev
+build-docker:
+	@echo "+ $@"
+	GOOS=linux GOARCH=amd64 make build-in-container
+	@docker build ${DOCKER_BUILD_FLAGS} \
+	-t ${DOCKER_IMAGE}:${DOCKER_TAG} \
+	-f ${CURDIR}/dockerfiles/Dockerfile.bundle .
+ifeq (${DOCKER_PUSH},true)
+	@docker push ${DOCKER_IMAGE}:${DOCKER_TAG}
+ifeq (${DOCKER_TAG_LATEST},true)
+	@docker tag ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_IMAGE}:latest
+	@docker push ${DOCKER_IMAGE}:latest
+endif
+endif

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,8 @@
 machine:
+  pre:
+    - curl -sSL https://s3.amazonaws.com/circle-downloads/install-circleci-docker.sh | bash -s -- 1.10.0
+  services:
+    - docker
   environment:
     OS: "linux"
     ARCH: "amd64"
@@ -36,3 +40,10 @@ test:
   post:
     # Report to codecov
     - cd $WORKDIR && bash <(curl -s https://codecov.io/bash)
+
+deployment:
+  docker:
+    branch: master
+    commands:
+      - docker login -e $DOCKER_HUB_EMAIL -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWD
+      - DOCKER_PUSH=true DOCKER_TAG_LATEST=true DOCKER_TAG="master-$CIRCLE_BUILD_NUM" DOCKER_BUILD_FLAGS="--rm=false" make build-docker

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,0 +1,25 @@
+FROM golang:1.7.4-alpine
+
+# A container for building InfraKit
+
+RUN apk add --update git make
+
+ENV CGO_ENABLED=0
+ENV GOPATH=/go
+ENV PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Development tools
+RUN go get github.com/rancher/trash \
+           github.com/golang/lint/golint \
+           github.com/golang/mock/gomock \
+           github.com/golang/mock/mockgen
+
+# The project sources
+ADD ./ /go/src/github.com/docker/infrakit.gcp
+WORKDIR /go/src/github.com/docker/infrakit.gcp
+
+VOLUME [ "/go/src/github.com/docker/infrakit.gcp/build" ]
+
+RUN trash  # Force updating the vendored sources per spec; this slows the build but is most correct.
+
+CMD make build-binaries

--- a/dockerfiles/Dockerfile.bundle
+++ b/dockerfiles/Dockerfile.bundle
@@ -1,0 +1,11 @@
+FROM alpine:3.4
+
+# InfraKit.gcp bundle: for GCP instance drivers
+# OSS - Use at your own risk - see project LICENSE for details
+
+MAINTAINER David Chung <david.chung@docker.com>
+
+RUN apk add --update ca-certificates && rm -Rf /tmp/* /var/lib/cache/apk/*
+RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
+ADD build/* /usr/local/bin/

--- a/plugin/instance/cmd/main.go
+++ b/plugin/instance/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/docker/infrakit.gcp/plugin"
 	"github.com/docker/infrakit.gcp/plugin/instance"
 	"github.com/docker/infrakit/pkg/cli"
 	instance_plugin "github.com/docker/infrakit/pkg/rpc/instance"
@@ -26,7 +27,7 @@ func main() {
 		return nil
 	}
 
-	cmd.AddCommand(cli.VersionCommand())
+	cmd.AddCommand(plugin.VersionCommand())
 
 	err := cmd.Execute()
 	if err != nil {

--- a/plugin/version.go
+++ b/plugin/version.go
@@ -1,0 +1,27 @@
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Version is the build release identifier.
+	Version = "Unspecified"
+
+	// Revision is the build source control revision.
+	Revision = "Unspecified"
+)
+
+// VersionCommand creates a cobra Command that prints build version information.
+func VersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "print build version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Version: %s\n", Version)
+			fmt.Printf("Revision: %s\n", Revision)
+		},
+	}
+}


### PR DESCRIPTION
Automation / Circle CI integration that will build the plugins as Docker container images

  + Sets the version / revision strings correctly
  + Adds Makefile targets to build inside a Docker container and for packaging as Docker image
  + Dockerfiles for the build/compile container and the deployed image
  + CircleCI integration to build images for all updates to master

In addition, a new Docker Hub repo has been created: `infrakit/gcp`.  The CircleCI account has been configured with the credentials of an automation account used by the build to push images to Docker Hub.  All successful commits to master branch will result in a Docker image tagged with the tag: master-<build_number>, as well as the `:latest` tag.

Signed-off-by: David Chung <david.chung@docker.com>