### PR TITLE
Reuse disk when a pet instance is created

### DIFF
--- a/plugin/instance/plugin.go
+++ b/plugin/instance/plugin.go
@@ -126,15 +126,17 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	}
 
 	if err = api.CreateInstance(name, &gcloud.InstanceSettings{
-		Description: properties.Description,
-		MachineType: properties.MachineType,
-		Network:     properties.Network,
-		Tags:        properties.Tags,
-		DiskSizeMb:  properties.DiskSizeMb,
-		DiskImage:   properties.DiskImage,
-		DiskType:    properties.DiskType,
-		Scopes:      properties.Scopes,
-		MetaData:    gcloud.TagsToMetaData(tags),
+		Description:       properties.Description,
+		MachineType:       properties.MachineType,
+		Network:           properties.Network,
+		Tags:              properties.Tags,
+		DiskSizeMb:        properties.DiskSizeMb,
+		DiskImage:         properties.DiskImage,
+		DiskType:          properties.DiskType,
+		Scopes:            properties.Scopes,
+		AutoDeleteDisk:    spec.LogicalID == nil,
+		ReuseExistingDisk: spec.LogicalID != nil,
+		MetaData:          gcloud.TagsToMetaData(tags),
 	}); err != nil {
 		return nil, err
 	}
@@ -187,7 +189,12 @@ scan:
 			}
 		}
 
-		logicalID := instance.LogicalID(inst.Name)
+		// When pets are deleted, we keep the disk
+		var logicalID instance.LogicalID
+		if !inst.Disks[0].AutoDelete {
+			logicalID = instance.LogicalID(inst.Name)
+		}
+
 		result = append(result, instance.Description{
 			LogicalID: &logicalID,
 			ID:        instance.ID(inst.Name),

--- a/plugin/instance/plugin_test.go
+++ b/plugin/instance/plugin_test.go
@@ -41,14 +41,16 @@ func TestProvision(t *testing.T) {
 	api, ctrl := NewMockGCloud(t)
 	defer ctrl.Finish()
 	api.EXPECT().CreateInstance("worker-8717895732742165505", &gcloud.InstanceSettings{
-		Description: "vm",
-		MachineType: "n1-standard-1",
-		Network:     "NETWORK",
-		Tags:        []string{"TAG1", "TAG2"},
-		DiskSizeMb:  100,
-		DiskImage:   "docker-image",
-		DiskType:    "ssd",
-		Scopes:      []string{"SCOPE1", "SCOPE2"},
+		Description:       "vm",
+		MachineType:       "n1-standard-1",
+		Network:           "NETWORK",
+		Tags:              []string{"TAG1", "TAG2"},
+		DiskSizeMb:        100,
+		DiskImage:         "docker-image",
+		DiskType:          "ssd",
+		Scopes:            []string{"SCOPE1", "SCOPE2"},
+		AutoDeleteDisk:    true,
+		ReuseExistingDisk: false,
 		MetaData: gcloud.TagsToMetaData(map[string]string{
 			"key1":           "value1",
 			"key2":           "value2",
@@ -76,12 +78,14 @@ func TestProvisionLogicalID(t *testing.T) {
 	api, ctrl := NewMockGCloud(t)
 	defer ctrl.Finish()
 	api.EXPECT().CreateInstance("LOGICAL-ID", &gcloud.InstanceSettings{
-		MachineType: "g1-small",
-		Network:     "default",
-		DiskSizeMb:  10,
-		DiskImage:   "docker",
-		DiskType:    "pd-standard",
-		MetaData:    gcloud.TagsToMetaData(map[string]string{}),
+		MachineType:       "g1-small",
+		Network:           "default",
+		DiskSizeMb:        10,
+		DiskImage:         "docker",
+		DiskType:          "pd-standard",
+		AutoDeleteDisk:    false,
+		ReuseExistingDisk: true,
+		MetaData:          gcloud.TagsToMetaData(map[string]string{}),
 	}).Return(nil)
 
 	logicalID := instance.LogicalID("LOGICAL-ID")
@@ -106,12 +110,14 @@ func TestProvisionFails(t *testing.T) {
 	rand.Seed(0)
 	api, _ := NewMockGCloud(t)
 	api.EXPECT().CreateInstance("instance-8717895732742165505", &gcloud.InstanceSettings{
-		MachineType: "g1-small",
-		Network:     "default",
-		DiskSizeMb:  10,
-		DiskImage:   "docker",
-		DiskType:    "pd-standard",
-		MetaData:    gcloud.TagsToMetaData(tags),
+		MachineType:       "g1-small",
+		Network:           "default",
+		DiskSizeMb:        10,
+		DiskImage:         "docker",
+		DiskType:          "pd-standard",
+		AutoDeleteDisk:    true,
+		ReuseExistingDisk: false,
+		MetaData:          gcloud.TagsToMetaData(tags),
 	}).Return(errors.New("BUG"))
 
 	plugin := &plugin{func() (gcloud.GCloud, error) { return api, nil }}
@@ -131,12 +137,14 @@ func TestProvisionFailsToAddToTargetPool(t *testing.T) {
 	rand.Seed(0)
 	api, _ := NewMockGCloud(t)
 	api.EXPECT().CreateInstance("instance-8717895732742165505", &gcloud.InstanceSettings{
-		MachineType: "g1-small",
-		Network:     "default",
-		DiskSizeMb:  10,
-		DiskImage:   "docker",
-		DiskType:    "pd-standard",
-		MetaData:    gcloud.TagsToMetaData(tags),
+		MachineType:       "g1-small",
+		Network:           "default",
+		DiskSizeMb:        10,
+		DiskImage:         "docker",
+		DiskType:          "pd-standard",
+		AutoDeleteDisk:    true,
+		ReuseExistingDisk: false,
+		MetaData:          gcloud.TagsToMetaData(tags),
 	}).Return(nil)
 	api.EXPECT().AddInstanceToTargetPool("POOL", "instance-8717895732742165505").Return(errors.New("BUG"))
 


### PR DESCRIPTION
Here's how a pet instance is different than a
cattle one:

 + It was created with a LogicalID which is mapped to the name of instance
 + It's boot disk shouldn't be deleted when the instance is deleted
 + It should try to reuse a pre-existing disk named after the LogicalID suffixed with `-disk`

Signed-off-by: David Gageot <david@gageot.net>