### PR TITLE
Use disk name as the logical ID for pets

### DIFF
--- a/plugin/instance/plugin.go
+++ b/plugin/instance/plugin.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit.gcp/plugin/gcloud"
@@ -112,9 +113,10 @@ func (p *plugin) DescribeInstances(tags map[string]string) ([]instance.Descripti
 			Tags: instTags,
 		}
 
-		// When pets are deleted, we keep the disk
+		// When pets are deleted, we keep the disk. So a machine with a disk that's not auto-deleted is
+		// assumed to be a pet and its logicalID is the name of the disk.
 		if len(inst.Disks) > 0 && !inst.Disks[0].AutoDelete {
-			id := instance.LogicalID(inst.Name)
+			id := instance.LogicalID(last(inst.Disks[0].Source))
 			description.LogicalID = &id
 		}
 
@@ -124,4 +126,9 @@ func (p *plugin) DescribeInstances(tags map[string]string) ([]instance.Descripti
 	log.Debugln("matching count:", len(result))
 
 	return result, nil
+}
+
+func last(url string) string {
+	parts := strings.Split(url, "/")
+	return parts[len(parts)-1]
 }

--- a/plugin/instance/plugin_test.go
+++ b/plugin/instance/plugin_test.go
@@ -232,6 +232,7 @@ func TestDescribeInstances(t *testing.T) {
 			},
 			Disks: []*compute.AttachedDisk{
 				{
+					Source:     "/projects/p/zones/z/disks/instance-pet-valid-disk",
 					AutoDelete: false,
 				},
 			},
@@ -275,7 +276,7 @@ func TestDescribeInstances(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(instances), 2)
 	require.Equal(t, "instance-pet-valid", string(instances[0].ID))
-	require.Equal(t, "instance-pet-valid", string(*instances[0].LogicalID))
+	require.Equal(t, "instance-pet-valid-disk", string(*instances[0].LogicalID))
 	require.Equal(t, "instance-cattle-valid", string(instances[1].ID))
 	require.Nil(t, instances[1].LogicalID)
 }


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>