### PR TITLE
Logical ID sets the private IP address

### DIFF
--- a/dockerfiles/Dockerfile.bundle
+++ b/dockerfiles/Dockerfile.bundle
@@ -2,4 +2,21 @@ FROM alpine:3.5
 
 RUN apk add --update ca-certificates
 
+RUN mkdir -p /infrakit/plugins /infrakit/configs /infrakit/logs
+
+VOLUME /infrakit
+VOLUME /infrakit/platforms/gcp/credentials.json
+
+ENV INFRAKIT_HOME /infrakit
+ENV INFRAKIT_PLUGINS_DIR /infrakit/plugins
+
+# For Google auth.  Be sure to bind mount the actual file to this location:
+ENV GOOGLE_APPLICATION_CREDENTIALS /infrakit/platforms/gcp/credentials.json
+
 ADD build/* /usr/local/bin/
+
+# Make symbolic links to make standardized bin names.
+# This makes for shorter names when containers are already scoped by the platform (eg. infrakit/gcp)
+RUN ln -s /usr/local/bin/infrakit-instance-gcp /usr/bin/instance
+RUN ln -s /usr/local/bin/infrakit-group-gcp /usr/bin/group
+RUN ln -s /usr/local/bin/infrakit-flavor-combo /usr/bin/flavor


### PR DESCRIPTION
1. Logical ID if set, will set the IP address.
2. Support Google auth via  GOOGLE_APPLICATION_CREDENTIALS as environment variable in the container, which points to a file path that the user is expected to bind mount to the actual credentials JSON file.

Signed-off-by: David Chung <david.chung@docker.com>