### PR TITLE
Improve LogicalID handling

### DIFF
--- a/plugin/group/plugin.go
+++ b/plugin/group/plugin.go
@@ -169,7 +169,7 @@ func (p *plugin) CommitGroup(config group.Spec, pretend bool) (string, error) {
 		settings.createdTemplates = append(settings.createdTemplates, templateName)
 
 		if createTemplate {
-			metadata, err := instance_types.ParseMetadata(settings.instanceSpec)
+			metadata, err := instance_types.ParseTags(settings.instanceSpec)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
+ Tag pets with their LogicalID
+ Pets whose LogicalID is an IP address now also have a fixed name
+ Tag pets/cattle with a version to make it possible for tagging strategy to evolve over time
+ Old pets that are not tagged are also recognized using the old heuristic

Signed-off-by: David Gageot <david@gageot.net>