### PR TITLE
The spec should say if boot disks should be deleted or reused.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ by GCP.
         "DiskSizeMb": 60,
         "DiskImage": "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20161205",
         "DiskType": "pd-standard",
+        "AutoDeleteDisk": false,
+        "ReuseExistingDisk": true,
         "Scopes": [
           "https://www.googleapis.com/auth/cloudruntimeconfig",
           "https://www.googleapis.com/auth/logging.write"

--- a/plugin/instance/plugin.go
+++ b/plugin/instance/plugin.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit.gcp/plugin/gcloud"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 	"google.golang.org/api/compute/v1"
-	"strings"
 )
 
 type plugin struct {
@@ -94,10 +94,6 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	// TODO - for now we overwrite, but support merging of MetaData field in the future, if the
 	// user provided some.
 	settings.MetaData = gcloud.TagsToMetaData(tags)
-
-	// Disks -- TODO - these may be better set externally.
-	settings.AutoDeleteDisk = spec.LogicalID == nil
-	settings.ReuseExistingDisk = spec.LogicalID != nil
 
 	if err = p.API.CreateInstance(name, settings); err != nil {
 		return nil, err

--- a/plugin/instance/plugin_test.go
+++ b/plugin/instance/plugin_test.go
@@ -82,7 +82,7 @@ func TestProvision(t *testing.T) {
 }
 
 func TestProvisionLogicalID(t *testing.T) {
-	properties := types.AnyString(`{}`)
+	properties := types.AnyString(`{ "AutoDeleteDisk":false, "ReuseExistingDisk":true }`)
 	tags := map[string]string{}
 
 	api, ctrl := NewMockGCloud(t)
@@ -128,8 +128,8 @@ func TestProvisionLogicalIDIsIPAddress(t *testing.T) {
 		DiskSizeMb:        10,
 		DiskImage:         "docker",
 		DiskType:          "pd-standard",
-		AutoDeleteDisk:    false,
-		ReuseExistingDisk: true,
+		AutoDeleteDisk:    true,
+		ReuseExistingDisk: false,
 		Preemptible:       false,
 		PrivateIP:         "10.20.1.100",
 		MetaData: gcloud.TagsToMetaData(map[string]string{


### PR DESCRIPTION
This should not be inferred from the LogicalID

Signed-off-by: David Gageot <david@gageot.net>