### PR TITLE
Store spec.Init under "startup-script" and "userdata"

### DIFF
--- a/plugin/instance/plugin_test.go
+++ b/plugin/instance/plugin_test.go
@@ -64,6 +64,7 @@ func TestProvision(t *testing.T) {
 			"key1":                 "value1",
 			"key2":                 "value2",
 			"startup-script":       "echo 'Startup'",
+			"userdata":             "echo 'Startup'",
 			"infrakit-gcp-version": "1",
 		}),
 	}).Return(nil)

--- a/plugin/instance/types/types.go
+++ b/plugin/instance/types/types.go
@@ -70,7 +70,11 @@ func ParseTags(spec instance.Spec) (map[string]string, error) {
 	}
 
 	if spec.Init != "" {
+		// spec.Init is special. Some plugins customise it via
+		// the templating mechanism and it can either be a
+		// startup script or just userdata. Store it twice.
 		tags["startup-script"] = spec.Init
+		tags["userdata"] = spec.Init
 	}
 
 	properties, err := ParseProperties(spec.Properties)


### PR DESCRIPTION
spec.Init is used by InfraKit to supply per-instance
customisation, often derived from a template. This is
not necessarily a script, so store it both under "startup-script"
and under "userdata"

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>